### PR TITLE
split on , for debian packages to handle multiple packages owning the sa...

### DIFF
--- a/lib/Alien/Packages/Dpkg.pm
+++ b/lib/Alien/Packages/Dpkg.pm
@@ -109,9 +109,12 @@ sub list_fileowners
             my @pkglist = split( /\n/, $stdout_buf->[0] );
             foreach my $pkg (@pkglist)
             {
-                if ( my ( $pkg_name, $fn ) = $pkg =~ m/^([^:]+):\s+([^\s].*)$/ )
+                if ( my ( $pkg_names, $fn ) = $pkg =~ m/^([^:]+):\s+([^\s].*)$/ )
                 {
-                    push( @{ $file_owners{$fn} }, { Package => $pkg_name } );
+                    foreach my $pkg_name (split /\s*,\s*/, $pkg_names)
+                    {
+                        push( @{ $file_owners{$fn} }, { Package => $pkg_name } );
+                    }
                 }
             }
         }


### PR DESCRIPTION
Currently I get multiple packages back from the debian implementation as a comma separated list

```
twin% perl -Ilib -MYAML -MAlien::Packages -E 'print YAML::Dump({Alien::Packages->new->list_fileowners("/bin")})'

---
/bin:
  - Package: 'login, tar, sysvinit-utils, bzip2, fuse, mount, ntfs-3g, bash, dash, grep, gzip, hostname, busybox, csh, xserver-xorg-input-vmmouse, initscripts, debianutils, console-setup, kmod, psmisc, base-files, sed, util-linux, coreutils, bsdutils, netcat-openbsd, ed, iputils-ping, net-tools, nano, netcat-traditional, less, fgetty, zsh, acl, tcsh, console-tools, iproute, cpio, procps, pax, live-tools'
    PkgType: dpkg
```

With this patch, I get it back as a list of hashes, which is what I think is intended from the documenttion:

```
twin% perl -Ilib -MYAML -MAlien::Packages -E 'print YAML::Dump({Alien::Packages->new->list_fileowners("/bin")})'

---
/bin:
  - Package: login
    PkgType: dpkg
  - Package: tar
    PkgType: dpkg
  - Package: sysvinit-utils
    PkgType: dpkg
  - Package: bzip2
    PkgType: dpkg
  - Package: fuse
    PkgType: dpkg
  - Package: mount
    PkgType: dpkg
  - Package: ntfs-3g
...
```
